### PR TITLE
Fix googlecode url

### DIFF
--- a/autobuild/install_helpers/02_gtest.sh
+++ b/autobuild/install_helpers/02_gtest.sh
@@ -6,9 +6,11 @@ fi
 
 test -d "$1" || (echo "Missing base directory" ; exit 1)
 cd $1
-PACKAGE_BASE=gtest-1.7.0
-test -e $PACKAGE_BASE.zip || wget https://googletest.googlecode.com/files/$PACKAGE_BASE.zip
-test -d $PACKAGE_BASE || unzip $PACKAGE_BASE.zip
+VERSION=1.7.0
+PACKAGE_URL=release-$VERSION
+PACKAGE_BASE=googletest-$PACKAGE_URL
+test -e $PACKAGE_BASE.zip || wget https://github.com/google/googletest/archive/$PACKAGE_URL.zip
+test -d $PACKAGE_BASE || unzip $PACKAGE_URL.zip
 cd $PACKAGE_BASE || exit 1
 cmake . || exit 1
 make || exit 1

--- a/autobuild/install_helpers/12_yaml_cpp.sh
+++ b/autobuild/install_helpers/12_yaml_cpp.sh
@@ -8,9 +8,11 @@ test -d "$1" || (echo "Missing base directory" ; exit 1)
 cd $1
 
 YAML_CPP_VERSION=0.3.0		#Newer versions are not compatible as of Fall 2014
-test -e yaml-cpp-$YAML_CPP_VERSION.tar.gz || wget https://yaml-cpp.googlecode.com/files/yaml-cpp-$YAML_CPP_VERSION.tar.gz || exit 1
-test -d yaml-cpp || (tar xf yaml-cpp-$YAML_CPP_VERSION.tar.gz) || exit 1
-cd yaml-cpp || exit 1
+PACKAGE_URL=release-$YAML_CPP_VERSION
+PACKAGE_BASE=yaml-cpp-$PACKAGE_URL
+test -e $PACKAGE_URL.tar.gz || wget https://github.com/jbeder/yaml-cpp/archive/$PACKAGE_URL.tar.gz || exit 1
+test -d $PACKAGE_BASE || (tar xf $PACKAGE_URL.tar.gz) || exit 1
+cd $PACKAGE_BASE || exit 1
 mkdir -p build
 cd build || exit 1
 test -e Makefile || cmake .. || exit 1


### PR DESCRIPTION
Googlecode's url is not being resolved to the correspondent github's.

This is probably fixed on the release version, once everything worked fine while running the "cygwin-jade7.exe" file. But when I tried to build ros and dependencies I faced these googlecode's issues.

Att.,
Igor Nunes
Instituto de Pesquisas Eldorado (www.eldorado.org.br)