### PR TITLE
Fix freetype location

### DIFF
--- a/autobuild/install_helpers/08_ogre.sh
+++ b/autobuild/install_helpers/08_ogre.sh
@@ -16,7 +16,11 @@ test -d ogre_src_v$OGRE_VERSION || (tar xf ogre_src_v$OGRE_VERSION.tar.bz2 && pa
 cd ogre_src_v$OGRE_VERSION || exit 1
 mkdir -p build
 cd build || exit 1
-test -e Makefile || cmake .. -DOGRE_BUILD_SAMPLES=FALSE || exit 1
+if [ -d "/usr/include/freetype2/freetype/" ]; then
+	test -e Makefile || cmake .. -DOGRE_BUILD_SAMPLES=FALSE -DFREETYPE_INCLUDE_DIR=/usr/include/freetype2/freetype/ || exit 1
+else
+	test -e Makefile || cmake .. -DOGRE_BUILD_SAMPLES=FALSE || exit 1
+fi
 echo Building Ogre...
 make $PARALLEL_BUILD_FLAGS || exit 1
 make install || exit 1


### PR DESCRIPTION
Same thing here. This is probably fixed on release version.

I nedded to setup manually the current freetype location in order to compile ogre.

Att.,
Igor Nunes
Instituto de Pesquisas Eldorado (www.eldorado.org.br)
